### PR TITLE
Refactored to use label selectors to skip resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ kubectl -n $NAMESPACE kubectl apply -k manifests/
  # Which Namespace To Kill Workloads
  - name: NAMESPACE
    value: example
- # Name of the Enforcer (So it doesnt delete itself)
- - name: EPHEMERAL_ENFORCER_NAME
-   value: "ephemeral-enforcer"
- # Comma Seperated List of Prefixes to skip
- - name: SKIPPED_PREFIXES
-   value: "default,kube"
  # When Should the Enforcer Check
  - name: ENFORCER_SCHEDULE
    value: "*/5 * * * *"
  # How Long Workloads Should Be Allowed to Live For (in minutes)
  - name: WORKLOAD_TTL
    value: "60"
+```
+
+If you would like to ephemeral enforcer to not delete your resource you can label it:
+
+```bash
+kubectl label deployment my-awesome-deployment ephemeral-enforcer=safe
 ```

--- a/manifests/base/deployment.yaml
+++ b/manifests/base/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: ephemeral-enforcer
+    ephemeral-enforcer: safe
   name: ephemeral-enforcer
 spec:
   replicas: 1

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -42,8 +42,8 @@ func GetEnv(key, fallback string) string {
 EphemeralChecks Struct that holds the information of the resources that could be deleted
 */
 type EphemeralChecks struct {
-	CreationTime metav1.Time
 	Name         string
+	CreationTime metav1.Time
 	Delete       bool
 }
 
@@ -55,25 +55,6 @@ func (e *EphemeralChecks) RunChecks() {
 	if passedTimeToLive(e.CreationTime) {
 		e.Delete = true
 	}
-	// Run The Check for Skipped Names
-	if !nameCheck(e.Name) {
-		e.Delete = false
-	}
-
-}
-
-func nameCheck(name string) bool {
-	ephemeralEnforcerName := GetEnv("EPHEMERAL_ENFORCER_NAME", "ephemeral-enforcer")
-	skippedPrefixes := GetEnv("SKIPPED_PREFIXES", "")
-	if strings.Contains(name, ephemeralEnforcerName) {
-		return false
-	}
-	for _, prefix := range strings.Split(skippedPrefixes, ",") {
-		if strings.Contains(name, prefix) && prefix != "" {
-			return false
-		}
-	}
-	return true
 }
 
 func passedTimeToLive(creationTime metav1.Time) bool {

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -69,19 +69,19 @@ func TestPassedTimeToLive(t *testing.T) {
 func TestEphemeralChecks(t *testing.T) {
 	os.Setenv("WORKLOAD_TTL", "1")
 	t.Run("Should fail Ephemeral Checks", func(t *testing.T) {
-		creationTime := time.Now().Add(time.Minute * time.Duration(2))
+		creationTime := time.Now().Add(0 - (time.Minute * time.Duration(3)))
 		shouldDelete := EphemeralChecks{
 			Name:         "pod-1234",
 			CreationTime: metav1.NewTime(creationTime),
 			Delete:       false,
 		}
 		shouldDelete.RunChecks()
-		if shouldDelete.Delete {
+		if !shouldDelete.Delete {
 			t.Errorf("delete = %v; want true", shouldDelete.Delete)
 		}
 	})
 	t.Run("Should pass Ephemeral Checks", func(t *testing.T) {
-		creationTime := time.Now().Add(time.Minute * time.Duration(2))
+		creationTime := time.Now().Add(time.Minute * time.Duration(1))
 		shouldNotDelete := EphemeralChecks{
 			Name:         "ephemeral-1234",
 			CreationTime: metav1.NewTime(creationTime),

--- a/pkg/helpers/helpers_test.go
+++ b/pkg/helpers/helpers_test.go
@@ -48,29 +48,6 @@ func TestCheckDeleteResourceAllowed(t *testing.T) {
 	})
 }
 
-func TestNameCheck(t *testing.T) {
-	os.Setenv("EPHEMERAL_ENFORCER_NAME", "ephemeral")
-	os.Setenv("SKIPPED_PREFIXES", "kube,default")
-	t.Run("Should return false for EPHEMERAL_ENFORCER_NAME", func(t *testing.T) {
-		deleteCheck := nameCheck("ephemeral-1234")
-		if deleteCheck {
-			t.Errorf("deleteCheck = %v; want false", deleteCheck)
-		}
-	})
-	t.Run("Should return false for SKIPPED_PREFIXES", func(t *testing.T) {
-		deleteCheck := nameCheck("default-1234")
-		if deleteCheck {
-			t.Errorf("deleteCheck = %v; want false", deleteCheck)
-		}
-	})
-	t.Run("Should return true for everything else", func(t *testing.T) {
-		deleteCheck := nameCheck("pod-1234")
-		if !deleteCheck {
-			t.Errorf("deleteCheck = %v; want true", deleteCheck)
-		}
-	})
-}
-
 func TestPassedTimeToLive(t *testing.T) {
 	os.Setenv("WORKLOAD_TTL", "1")
 	t.Run("Should return false for time thats not over ttl", func(t *testing.T) {
@@ -91,7 +68,6 @@ func TestPassedTimeToLive(t *testing.T) {
 
 func TestEphemeralChecks(t *testing.T) {
 	os.Setenv("WORKLOAD_TTL", "1")
-	os.Setenv("EPHEMERAL_ENFORCER_NAME", "ephemeral")
 	t.Run("Should fail Ephemeral Checks", func(t *testing.T) {
 		creationTime := time.Now().Add(time.Minute * time.Duration(2))
 		shouldDelete := EphemeralChecks{

--- a/pkg/workloadkiller/workloadkiller.go
+++ b/pkg/workloadkiller/workloadkiller.go
@@ -69,10 +69,17 @@ func logDeletes(number int, resource string) {
 	log.Printf("There are %d %v scheduled for deletion\n", number, resource)
 }
 
+/*
+getLabelSelectors returns the label selector that is used to get pods to delete
+*/
+func getLabelSelectors() string {
+	return "!ephemeral-enforcer"
+}
+
 func deleteDeployments(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.AppsV1().Deployments(*namespace)
-	deployments, err := client.List(context.TODO(), metav1.ListOptions{})
+	deployments, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}
@@ -99,7 +106,7 @@ func deleteDeployments(clientset kubernetes.Interface, namespace *string, wg *sy
 func deleteStatefulsets(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.AppsV1().StatefulSets(*namespace)
-	statefulsets, err := client.List(context.TODO(), metav1.ListOptions{})
+	statefulsets, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}
@@ -126,7 +133,7 @@ func deleteStatefulsets(clientset kubernetes.Interface, namespace *string, wg *s
 func deleteServices(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.CoreV1().Services(*namespace)
-	services, err := client.List(context.TODO(), metav1.ListOptions{})
+	services, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}
@@ -153,7 +160,7 @@ func deleteServices(clientset kubernetes.Interface, namespace *string, wg *sync.
 func deleteSecrets(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.CoreV1().Secrets(*namespace)
-	secrets, err := client.List(context.TODO(), metav1.ListOptions{})
+	secrets, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}
@@ -180,7 +187,7 @@ func deleteSecrets(clientset kubernetes.Interface, namespace *string, wg *sync.W
 func deleteConfigMaps(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.CoreV1().ConfigMaps(*namespace)
-	configmaps, err := client.List(context.TODO(), metav1.ListOptions{})
+	configmaps, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}
@@ -207,7 +214,7 @@ func deleteConfigMaps(clientset kubernetes.Interface, namespace *string, wg *syn
 func deleteDaemonSets(clientset kubernetes.Interface, namespace *string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	client := clientset.AppsV1().DaemonSets(*namespace)
-	daemonsets, err := client.List(context.TODO(), metav1.ListOptions{})
+	daemonsets, err := client.List(context.TODO(), metav1.ListOptions{LabelSelector: getLabelSelectors()})
 	if err != nil {
 		log.Fatal("Error:", err.Error())
 	}

--- a/pkg/workloadkiller/workloadkiller_test.go
+++ b/pkg/workloadkiller/workloadkiller_test.go
@@ -22,6 +22,9 @@ func TestKillWorkloads(t *testing.T) {
 				Name:        "ephemeral",
 				Namespace:   "default",
 				Annotations: map[string]string{},
+				Labels: map[string]string{
+					"ephemeral-enforcer": "safe",
+				},
 			},
 		},
 		&appsv1.Deployment{
@@ -75,6 +78,9 @@ func TestDeleteDeployments(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -109,6 +115,9 @@ func TestDeleteDaemonSets(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -142,6 +151,9 @@ func TestDeleteStatefulSets(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -176,6 +188,9 @@ func TestDeleteServices(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -210,6 +225,9 @@ func TestDeleteSecrets(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -244,6 +262,9 @@ func TestDeleteConfigMaps(t *testing.T) {
 			Name:        "ephemeral",
 			Namespace:   "default",
 			Annotations: map[string]string{},
+			Labels: map[string]string{
+				"ephemeral-enforcer": "safe",
+			},
 		},
 	}, &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description

This allows using the label `ephemeral-enforcer=safe` on a resource in order for Ephemeral Enforcer to skip deleting it. 

Linke to issue: https://github.com/Spazzy757/ephemeral-enforcer/issues/22

## Solution

Remove the `SKIPPED_PREFIXES` env and now only use the above label to skip the delete of resources

## Checklist

- [x] All Tests Pass
- [x] No Changes Made Not Directly Linked to Solution
- [x] Code Comments

